### PR TITLE
[PKG-4740] 0.3.0 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,3 @@ about:
   license_file: LICENSE
   summary: Streamlit Component for rendering kepler.gl maps
   description: Streamlit component for rendering kepler.gl maps in a streamlit app.
-
-
-  

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<36]
+  # skip s390x, missing keplergl.
+  skip: true  # [py<36 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,47 @@
+{% set name = "streamlit-keplergl" %}
+{% set version = "0.3.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/chrieke/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 691fa923491cabd59f95ea08e0a98025b9f994fe3fb2865b1d46eb443c31d774
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<36]
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python
+    - keplergl
+    - streamlit >=0.79
+  
+test:
+  imports:
+    - streamlit_keplergl
+  requires:
+    - pip
+  commands:
+    - pip check
+
+about:
+  home: https://github.com/chrieke/streamlit-keplergl
+  doc_url: https://github.com/chrieke/streamlit-keplergl/blob/main/README.md
+  dev_url: https://github.com/chrieke/streamlit-keplergl
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: Streamlit Component for rendering kepler.gl maps
+  description: Streamlit component for rendering kepler.gl maps in a streamlit app.
+
+
+  


### PR DESCRIPTION
streamlit-keplergl 0.3.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4740]
- [Upstream repository](https://github.com/chrieke/streamlit-keplergl)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/keplergl-feedstock/pull/2

### Explanation of changes:

- New recipe from scratch.
- No upstream tests available.
- Skip s390x due to missing `keplergl`


[PKG-4740]: https://anaconda.atlassian.net/browse/PKG-4740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ